### PR TITLE
Implement server-side interception of unary RPC methods.

### DIFF
--- a/internal/generator/call.go
+++ b/internal/generator/call.go
@@ -24,6 +24,7 @@ func appendRuntimeCallConstructor(
 		Params(
 			jen.Id("ctx").Qual("context", "Context"),
 			jen.Id("service").Id(s.ServiceInterface()),
+			jen.Id("interceptor").Qual(middlewarePackage, "ServerInterceptor"),
 		).
 		Params(
 			jen.Qual(runtimePackage, "Call"),
@@ -77,7 +78,7 @@ func appendRuntimeCallImpl(
 		Id("Recv").
 		Params().
 		Params(
-			jen.Qual("google.golang.org/protobuf/proto", "Message"),
+			jen.Qual(protoPackage, "Message"),
 			jen.Bool(),
 			jen.Error(),
 		).

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -8,8 +8,10 @@ import (
 )
 
 const (
-	rootPackage    = "github.com/dogmatiq/protean"
-	runtimePackage = rootPackage + "/runtime"
+	protoPackage      = "google.golang.org/protobuf/proto"
+	rootPackage       = "github.com/dogmatiq/protean"
+	runtimePackage    = rootPackage + "/runtime"
+	middlewarePackage = rootPackage + "/middleware"
 )
 
 // Generator produces a code generation response from a request.

--- a/internal/generator/method.go
+++ b/internal/generator/method.go
@@ -72,6 +72,7 @@ func appendRuntimeMethodImpl(code *jen.File, s *scope.Method) {
 		Id("NewCall").
 		Params(
 			jen.Id("ctx").Qual("context", "Context"),
+			jen.Id("interceptor").Qual(middlewarePackage, "ServerInterceptor"),
 		).
 		Params(
 			jen.Qual(runtimePackage, "Call"),
@@ -80,6 +81,7 @@ func appendRuntimeMethodImpl(code *jen.File, s *scope.Method) {
 			jen.Id(s.RuntimeCallConstructor()).Call(
 				jen.Id("ctx"),
 				jen.Id("m").Dot("service"),
+				jen.Id("interceptor"),
 			),
 		))
 }

--- a/internal/testservice/service.go
+++ b/internal/testservice/service.go
@@ -1,0 +1,21 @@
+package testservice
+
+import "errors"
+
+// Validate returns an error if the message is invalid.
+func (m *Input) Validate() error {
+	if m.GetData() == "" {
+		return errors.New("input data must not be empty")
+	}
+
+	return nil
+}
+
+// Validate returns an error if the message is invalid.
+func (m *Output) Validate() error {
+	if m.GetData() == "" {
+		return errors.New("output data must not be empty")
+	}
+
+	return nil
+}

--- a/middleware/doc.go
+++ b/middleware/doc.go
@@ -1,0 +1,4 @@
+// Package middleware defines interfaces that can be implemented by third-party
+// code to intercept RPC method invocations, both on the server-side and
+// client-side.
+package middleware

--- a/middleware/ginkgo_test.go
+++ b/middleware/ginkgo_test.go
@@ -1,0 +1,15 @@
+package middleware_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	type tag struct{}
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, reflect.TypeOf(tag{}).PkgPath())
+}

--- a/middleware/server.go
+++ b/middleware/server.go
@@ -1,0 +1,79 @@
+package middleware
+
+import (
+	"context"
+
+	"google.golang.org/protobuf/proto"
+)
+
+// UnaryServerInfo encapsulates information about a call to unary RPC method and
+// makes it available to a ServerInterceptor implementation.
+type UnaryServerInfo struct {
+	// Package is the name of the Protocol Buffers package that contains the
+	// service definition.
+	Package string
+
+	// Service is the name of the RPC service.
+	Service string
+
+	// Method is the name of the RPC method being invoked.
+	Method string
+}
+
+// ServerInterceptor is an interface intercepting RPC method calls on the
+// server-side.
+// server.
+type ServerInterceptor interface {
+	// InterceptUnaryRPC is called before the RPC method is invoked.
+	//
+	// It must call next() to forward the call to the next interceptor in the
+	// chain, or ultimately to the application-defined server implementation.
+	//
+	// It returns the output that should be sent to the client.
+	//
+	// The RPC input message may be mutated in place. The output message
+	// returned by next() must not be modified. To produce different RPC output,
+	// return a new output message or error.
+	InterceptUnaryRPC(
+		ctx context.Context,
+		info UnaryServerInfo,
+		in proto.Message,
+		next func(ctx context.Context) (out proto.Message, err error),
+	) (proto.Message, error)
+}
+
+// ServerChain is a ServerInterceptor that chains multiple interceptors to be
+// applied sequentially.
+type ServerChain []ServerInterceptor
+
+// InterceptUnaryRPC is called before the RPC method is invoked.
+//
+// It must call next() to forward the call to the next interceptor in the
+// chain, or ultimately to the application-defined server implementation.
+//
+// It returns the output that should be sent to the client.
+//
+// The RPC input message may be mutated in place. The output message
+// returned by next() must not be modified. To produce different RPC output,
+// return a new output message or error.
+func (c ServerChain) InterceptUnaryRPC(
+	ctx context.Context,
+	info UnaryServerInfo,
+	in proto.Message,
+	next func(ctx context.Context) (out proto.Message, err error),
+) (proto.Message, error) {
+	if len(c) == 0 {
+		return next(ctx)
+	}
+
+	head, tail := c[0], c[1:]
+
+	return head.InterceptUnaryRPC(
+		ctx,
+		info,
+		in,
+		func(ctx context.Context) (out proto.Message, err error) {
+			return tail.InterceptUnaryRPC(ctx, info, in, next)
+		},
+	)
+}

--- a/middleware/server_test.go
+++ b/middleware/server_test.go
@@ -1,0 +1,128 @@
+package middleware_test
+
+import (
+	"context"
+	"errors"
+
+	"github.com/dogmatiq/protean/internal/testservice"
+	. "github.com/dogmatiq/protean/middleware"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/proto"
+)
+
+var _ = Describe("type ServerChain", func() {
+	Describe("func InterceptUnaryRPC()", func() {
+		It("calls each interceptor in the chain", func() {
+			info := UnaryServerInfo{
+				Package: "<package>",
+				Service: "<service>",
+				Method:  "<method>",
+			}
+
+			chain := ServerChain{
+				&serverStub{
+					InterceptUnaryRPCFunc: func(
+						ctx context.Context,
+						i UnaryServerInfo,
+						in proto.Message,
+						next func(ctx context.Context) (out proto.Message, err error),
+					) (proto.Message, error) {
+						Expect(i).To(Equal(info))
+
+						{
+							m, ok := in.(*testservice.Input)
+							Expect(ok).To(BeTrue())
+							Expect(m.GetData()).To(Equal("<input one>"))
+							m.Data = "<input two>"
+						}
+
+						out, err := next(ctx)
+						Expect(err).To(MatchError("<error two>"))
+
+						{
+							m, ok := out.(*testservice.Output)
+							Expect(ok).To(BeTrue())
+							Expect(m.GetData()).To(Equal("<output two>"))
+						}
+
+						return &testservice.Output{
+							Data: "<output three>",
+						}, errors.New("<error three>")
+					},
+				},
+				&serverStub{
+					InterceptUnaryRPCFunc: func(
+						ctx context.Context,
+						i UnaryServerInfo,
+						in proto.Message,
+						next func(ctx context.Context) (out proto.Message, err error),
+					) (proto.Message, error) {
+						Expect(i).To(Equal(info))
+
+						{
+							m, ok := in.(*testservice.Input)
+							Expect(ok).To(BeTrue())
+							Expect(m.GetData()).To(Equal("<input two>"))
+							m.Data = "<input three>"
+						}
+
+						out, err := next(ctx)
+						Expect(err).To(MatchError("<error one>"))
+
+						{
+							m, ok := out.(*testservice.Output)
+							Expect(ok).To(BeTrue())
+							Expect(m.GetData()).To(Equal("<output one>"))
+						}
+
+						return &testservice.Output{
+							Data: "<output two>",
+						}, errors.New("<error two>")
+					},
+				},
+			}
+
+			out, err := chain.InterceptUnaryRPC(
+				context.Background(),
+				info,
+				&testservice.Input{
+					Data: "<input one>",
+				},
+				func(ctx context.Context) (out proto.Message, err error) {
+					return &testservice.Output{
+						Data: "<output one>",
+					}, errors.New("<error one>")
+				},
+			)
+
+			Expect(err).To(MatchError("<error three>"))
+
+			m, ok := out.(*testservice.Output)
+			Expect(ok).To(BeTrue())
+			Expect(m.GetData()).To(Equal("<output three>"))
+		})
+	})
+})
+
+type serverStub struct {
+	InterceptUnaryRPCFunc func(
+		ctx context.Context,
+		info UnaryServerInfo,
+		in proto.Message,
+		next func(ctx context.Context) (out proto.Message, err error),
+	) (proto.Message, error)
+}
+
+func (s *serverStub) InterceptUnaryRPC(
+	ctx context.Context,
+	info UnaryServerInfo,
+	in proto.Message,
+	next func(ctx context.Context) (out proto.Message, err error),
+) (proto.Message, error) {
+	if s.InterceptUnaryRPCFunc != nil {
+		return s.InterceptUnaryRPCFunc(ctx, info, in, next)
+	}
+
+	return next(ctx)
+}

--- a/middleware/validation.go
+++ b/middleware/validation.go
@@ -1,0 +1,60 @@
+package middleware
+
+import (
+	"context"
+
+	"github.com/dogmatiq/protean/rpcerror"
+	"google.golang.org/protobuf/proto"
+)
+
+// ValidatableMessage is an RPC input or output message that provides its own
+// validation.
+type ValidatableMessage interface {
+	proto.Message
+
+	// Validate returns an error if the message is invalid.
+	//
+	// The error message may be sent to the RPC client, and as such should not
+	// contain any sensitive information.
+	Validate() error
+}
+
+// Validator is an implementation of ServerInterceptor that validates RPC input
+// and messages by calling their Validate() method, if present.
+//
+// The Validator interceptor is installed by default.
+type Validator struct{}
+
+// InterceptUnaryRPC returns an error if any RPC input or output message that
+// implements ValidatableMessage is invalid.
+func (Validator) InterceptUnaryRPC(
+	ctx context.Context,
+	info UnaryServerInfo,
+	in proto.Message,
+	next func(ctx context.Context) (out proto.Message, err error),
+) (proto.Message, error) {
+	if in, ok := in.(ValidatableMessage); ok {
+		if err := in.Validate(); err != nil {
+			return nil, rpcerror.New(
+				rpcerror.InvalidInput,
+				err.Error(),
+			)
+		}
+	}
+
+	out, err := next(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if out, ok := out.(ValidatableMessage); ok {
+		if err := out.Validate(); err != nil {
+			return nil, rpcerror.New(
+				rpcerror.Unknown,
+				"the server produced invalid RPC output",
+			).WithCause(err)
+		}
+	}
+
+	return out, nil
+}

--- a/middleware/validation.go
+++ b/middleware/validation.go
@@ -37,6 +37,7 @@ func (Validator) InterceptUnaryRPC(
 		if err := in.Validate(); err != nil {
 			return nil, rpcerror.New(
 				rpcerror.InvalidInput,
+				"the RPC input message is invalid: %s",
 				err.Error(),
 			)
 		}
@@ -51,7 +52,7 @@ func (Validator) InterceptUnaryRPC(
 		if err := out.Validate(); err != nil {
 			return nil, rpcerror.New(
 				rpcerror.Unknown,
-				"the server produced invalid RPC output",
+				"the server produced an invalid RPC output message",
 			).WithCause(err)
 		}
 	}

--- a/middleware/validation_test.go
+++ b/middleware/validation_test.go
@@ -1,0 +1,118 @@
+package middleware_test
+
+import (
+	"context"
+	"errors"
+
+	"github.com/dogmatiq/protean/internal/stringservice"
+	"github.com/dogmatiq/protean/internal/testservice"
+	. "github.com/dogmatiq/protean/middleware"
+	"github.com/dogmatiq/protean/rpcerror"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/proto"
+)
+
+var _ = Describe("type Validator", func() {
+	var validator Validator
+
+	Describe("func InterceptUnaryRPC()", func() {
+		When("the messages implement ValidatableMessage", func() {
+			It("behaves normally if both messages are valid", func() {
+				expect := &testservice.Output{
+					Data: "<data>",
+				}
+
+				out, err := validator.InterceptUnaryRPC(
+					context.Background(),
+					UnaryServerInfo{},
+					&testservice.Input{
+						Data: "<data>",
+					},
+					func(ctx context.Context) (proto.Message, error) {
+						return expect, nil
+					},
+				)
+
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(out).To(BeIdenticalTo(expect))
+			})
+
+			It("does not call next() if the input message is invalid", func() {
+				_, err := validator.InterceptUnaryRPC(
+					context.Background(),
+					UnaryServerInfo{},
+					&testservice.Input{
+						Data: "", // invalid
+					},
+					func(ctx context.Context) (proto.Message, error) {
+						Fail("unexpected call")
+						return nil, nil
+					},
+				)
+
+				Expect(err).To(Equal(
+					rpcerror.New(
+						rpcerror.InvalidInput,
+						"the RPC input message is invalid: input data must not be empty",
+					),
+				))
+			})
+
+			It("returns an error if the output message is invalid", func() {
+				_, err := validator.InterceptUnaryRPC(
+					context.Background(),
+					UnaryServerInfo{},
+					&testservice.Input{
+						Data: "<data>",
+					},
+					func(ctx context.Context) (proto.Message, error) {
+						return &testservice.Output{
+							Data: "", // invalid
+						}, nil
+					},
+				)
+
+				Expect(err).To(Equal(
+					rpcerror.New(
+						rpcerror.Unknown,
+						"the server produced an invalid RPC output message",
+					).WithCause(
+						errors.New("output data must not be empty"),
+					),
+				))
+			})
+		})
+
+		When("the messages do not implement ValidatableMessage", func() {
+			It("calls next() and returns its result", func() {
+				expect := &stringservice.ToUpperResponse{}
+
+				out, err := validator.InterceptUnaryRPC(
+					context.Background(),
+					UnaryServerInfo{},
+					&stringservice.ToUpperRequest{},
+					func(ctx context.Context) (proto.Message, error) {
+						return expect, nil
+					},
+				)
+
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(out).To(BeIdenticalTo(expect))
+			})
+		})
+
+		It("it returns the error returned by next()", func() {
+			_, err := validator.InterceptUnaryRPC(
+				context.Background(),
+				UnaryServerInfo{},
+				&stringservice.ToUpperRequest{},
+				func(ctx context.Context) (proto.Message, error) {
+					return nil, errors.New("<error>")
+				},
+			)
+
+			Expect(err).To(MatchError("<error>"))
+		})
+	})
+})

--- a/post.go
+++ b/post.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/dogmatiq/protean/internal/proteanpb"
 	"github.com/dogmatiq/protean/internal/protomime"
+	"github.com/dogmatiq/protean/middleware"
 	"github.com/dogmatiq/protean/rpcerror"
 	"github.com/dogmatiq/protean/runtime"
 	"google.golang.org/protobuf/proto"
@@ -201,12 +202,12 @@ func (h *PostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	call := method.NewCall(r.Context())
+	call := method.NewCall(r.Context(), middleware.Validator{})
 	defer call.Done()
 
 	// Send never blocks on unary RPC methods.
-	if _, err := call.Send(func(m proto.Message) error {
-		return unmarshaler.Unmarshal(data, m)
+	if _, err := call.Send(func(in proto.Message) error {
+		return unmarshaler.Unmarshal(data, in)
 	}); err != nil {
 		httpError(
 			w,

--- a/rpcerror/code.go
+++ b/rpcerror/code.go
@@ -8,6 +8,10 @@ type Code struct{ n int32 }
 var (
 	// Unknown is an error code used when no information is available about the
 	// error.
+	//
+	// The Unknown code is used whenever the server behaves incorrectly. Even
+	// though the reason may be known on the server, it is inappropriate to
+	// provide granular information about these errors to the client.
 	Unknown = Code{0}
 
 	// InvalidInput is an error code that indicates that the input message to

--- a/runtime/service.go
+++ b/runtime/service.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 
+	"github.com/dogmatiq/protean/middleware"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -55,7 +56,7 @@ type Method interface {
 	//
 	// ctx is the context for the lifetime of the call, including any time taken
 	// to stream input and output messages.
-	NewCall(ctx context.Context) Call
+	NewCall(ctx context.Context, i middleware.ServerInterceptor) Call
 }
 
 // Call represents a single invocation of an RPC method.


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR adds the `middleware` package which defines the `ServerInterceptor` interface that can be used to intercept RPC calls on the server-side.

It also includes the `Validator` type, which is an implementation of `ServerInterceptor` that validates messages by calling their `Validate()` method, if present.

#### Why make this change?

This kind of middleware is how we will implement things like logging, tracing, metrics (and the included validation) without baking any specific behavior into the library.

#### Is there anything you are unsure about?

At this point I've used a single interface, with the intent that it will grow methods for intercepting the streaming RPC methods in the future.  This is a departure from what both gRPC and Twirp do (they use single functions for intercepting each type of RPC method).

I have chosen this approach because looking at the kinds of interceptors we expect to implement (logging, tracing, metrics, etc), it seems reasonable that you'd want to perform these actions regardless of whether the RPC method uses streaming or not, without requiring the user to register separate interceptors.

#### What issues does this relate to?

Fixes #7
