### PR TITLE
Add MIME parameters when marshaling.

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -3,6 +3,7 @@ package protean
 import (
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"strconv"
 	"strings"
@@ -297,6 +298,13 @@ func (h *postHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	outputMediaType = mime.FormatMediaType(
+		outputMediaType,
+		map[string]string{
+			"proto": string(proto.MessageName(out)),
+		},
+	)
+
 	w.Header().Add("Content-Type", outputMediaType)
 	w.Header().Add("Content-Length", strconv.Itoa(len(data)))
 	w.WriteHeader(http.StatusOK)
@@ -366,7 +374,15 @@ func httpError(
 		panic(err)
 	}
 
+	mediaType = mime.FormatMediaType(
+		mediaType,
+		map[string]string{
+			"proto": string(proto.MessageName(&protoErr)),
+		},
+	)
+
 	w.Header().Set("Content-Type", mediaType)
+	w.Header().Add("Content-Length", strconv.Itoa(len(data)))
 	w.WriteHeader(status)
 	_, _ = w.Write(data)
 }

--- a/handler.go
+++ b/handler.go
@@ -3,7 +3,6 @@ package protean
 import (
 	"fmt"
 	"io"
-	"mime"
 	"net/http"
 	"strconv"
 	"strings"
@@ -298,14 +297,7 @@ func (h *postHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	outputMediaType = mime.FormatMediaType(
-		outputMediaType,
-		map[string]string{
-			"proto": string(proto.MessageName(out)),
-		},
-	)
-
-	w.Header().Add("Content-Type", outputMediaType)
+	w.Header().Add("Content-Type", protomime.FormatMediaType(outputMediaType, out))
 	w.Header().Add("Content-Length", strconv.Itoa(len(data)))
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(data)
@@ -374,14 +366,7 @@ func httpError(
 		panic(err)
 	}
 
-	mediaType = mime.FormatMediaType(
-		mediaType,
-		map[string]string{
-			"proto": string(proto.MessageName(&protoErr)),
-		},
-	)
-
-	w.Header().Set("Content-Type", mediaType)
+	w.Header().Set("Content-Type", protomime.FormatMediaType(mediaType, &protoErr))
 	w.Header().Add("Content-Length", strconv.Itoa(len(data)))
 	w.WriteHeader(status)
 	_, _ = w.Write(data)

--- a/handler_test.go
+++ b/handler_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -305,7 +306,7 @@ var _ = Describe("type Handler", func() {
 					handler.ServeHTTP(response, request)
 
 					Expect(response).To(HaveHTTPStatus(http.StatusOK))
-					Expect(response).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
+					Expect(response).To(HaveHTTPHeaderWithValue("Content-Type", "application/json; proto=protean.test.Output"))
 					expectStandardHeaders(response)
 
 					data, err := io.ReadAll(response.Body)
@@ -357,7 +358,7 @@ var _ = Describe("type Handler", func() {
 						handler.ServeHTTP(response, request)
 
 						Expect(response).To(HaveHTTPStatus(http.StatusOK))
-						Expect(response).To(HaveHTTPHeaderWithValue("Content-Type", mediaType))
+						Expect(response).To(HaveHTTPHeaderWithValue("Content-Type", mediaType+"; proto=protean.test.Output"))
 						expectStandardHeaders(response)
 
 						data, err := io.ReadAll(response.Body)
@@ -421,7 +422,7 @@ var _ = Describe("type Handler", func() {
 					handler.ServeHTTP(response, request)
 
 					Expect(response).To(HaveHTTPStatus(http.StatusOK))
-					Expect(response).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
+					Expect(response).To(HaveHTTPHeaderWithValue("Content-Type", "application/json; proto=protean.test.Output"))
 					expectStandardHeaders(response)
 
 					data, err := io.ReadAll(response.Body)
@@ -469,7 +470,7 @@ var _ = Describe("type Handler", func() {
 					handler.ServeHTTP(response, request)
 
 					Expect(response).To(HaveHTTPStatus(http.StatusOK))
-					Expect(response).To(HaveHTTPHeaderWithValue("Content-Type", "text/plain"))
+					Expect(response).To(HaveHTTPHeaderWithValue("Content-Type", "text/plain; proto=protean.test.Output"))
 					expectStandardHeaders(response)
 
 					data, err := io.ReadAll(response.Body)
@@ -815,8 +816,15 @@ func expectError(
 	mediaType string,
 	expect rpcerror.Error,
 ) {
+	expectedMediaType := mime.FormatMediaType(
+		mediaType,
+		map[string]string{
+			"proto": "protean.v1.Error",
+		},
+	)
+
 	Expect(response).To(HaveHTTPStatus(status))
-	Expect(response).To(HaveHTTPHeaderWithValue("Content-Type", mediaType))
+	Expect(response).To(HaveHTTPHeaderWithValue("Content-Type", expectedMediaType))
 
 	data, err := io.ReadAll(response.Body)
 	Expect(err).ShouldNot(HaveOccurred())

--- a/handler_test.go
+++ b/handler_test.go
@@ -128,7 +128,7 @@ var _ = Describe("type Handler", func() {
 					expectError(
 						response,
 						httpCode,
-						"application/json",
+						"application/json; x-proto=protean.v1.Error",
 						rpcerror.New(errorCode, "<error>"),
 					)
 					expectStandardHeaders(response)
@@ -159,7 +159,7 @@ var _ = Describe("type Handler", func() {
 				expectError(
 					response,
 					http.StatusInternalServerError,
-					"application/json",
+					"application/json; x-proto=protean.v1.Error",
 					rpcerror.New(
 						rpcerror.Unknown,
 						"the RPC method returned an unrecognized error",
@@ -233,7 +233,7 @@ var _ = Describe("type Handler", func() {
 					expectError(
 						response,
 						http.StatusInternalServerError,
-						"application/json",
+						"application/json; x-proto=protean.v1.Error",
 						rpcerror.New(
 							rpcerror.Unknown,
 							"the request body could not be read",
@@ -257,7 +257,7 @@ var _ = Describe("type Handler", func() {
 					expectError(
 						response,
 						http.StatusBadRequest,
-						"application/json",
+						"application/json; x-proto=protean.v1.Error",
 						rpcerror.New(
 							rpcerror.InvalidInput,
 							"the RPC input message is invalid: input data must not be empty",
@@ -282,7 +282,7 @@ var _ = Describe("type Handler", func() {
 					expectError(
 						response,
 						http.StatusBadRequest,
-						"application/json",
+						"application/json; x-proto=protean.v1.Error",
 						rpcerror.New(
 							rpcerror.Unknown,
 							"the RPC input message could not be unmarshaled from the request body",
@@ -306,7 +306,7 @@ var _ = Describe("type Handler", func() {
 					handler.ServeHTTP(response, request)
 
 					Expect(response).To(HaveHTTPStatus(http.StatusOK))
-					Expect(response).To(HaveHTTPHeaderWithValue("Content-Type", "application/json; proto=protean.test.Output"))
+					Expect(response).To(HaveHTTPHeaderWithValue("Content-Type", "application/json; x-proto=protean.test.Output"))
 					expectStandardHeaders(response)
 
 					data, err := io.ReadAll(response.Body)
@@ -334,7 +334,7 @@ var _ = Describe("type Handler", func() {
 					expectError(
 						response,
 						http.StatusInternalServerError,
-						"application/json",
+						"application/json; x-proto=protean.v1.Error",
 						rpcerror.New(
 							rpcerror.Unknown,
 							"the RPC method returned an unrecognized error",
@@ -358,7 +358,7 @@ var _ = Describe("type Handler", func() {
 						handler.ServeHTTP(response, request)
 
 						Expect(response).To(HaveHTTPStatus(http.StatusOK))
-						Expect(response).To(HaveHTTPHeaderWithValue("Content-Type", mediaType+"; proto=protean.test.Output"))
+						Expect(response).To(HaveHTTPHeaderWithValue("Content-Type", mediaType+"; x-proto=protean.test.Output"))
 						expectStandardHeaders(response)
 
 						data, err := io.ReadAll(response.Body)
@@ -397,7 +397,7 @@ var _ = Describe("type Handler", func() {
 						expectError(
 							response,
 							http.StatusInternalServerError,
-							mediaType,
+							mediaType+"; x-proto=protean.v1.Error",
 							rpcerror.New(
 								rpcerror.Unknown,
 								"the RPC method returned an unrecognized error",
@@ -422,7 +422,7 @@ var _ = Describe("type Handler", func() {
 					handler.ServeHTTP(response, request)
 
 					Expect(response).To(HaveHTTPStatus(http.StatusOK))
-					Expect(response).To(HaveHTTPHeaderWithValue("Content-Type", "application/json; proto=protean.test.Output"))
+					Expect(response).To(HaveHTTPHeaderWithValue("Content-Type", "application/json; x-proto=protean.test.Output"))
 					expectStandardHeaders(response)
 
 					data, err := io.ReadAll(response.Body)
@@ -448,7 +448,7 @@ var _ = Describe("type Handler", func() {
 					expectError(
 						response,
 						http.StatusInternalServerError,
-						"application/json",
+						"application/json; x-proto=protean.v1.Error",
 						rpcerror.New(
 							rpcerror.Unknown,
 							"the RPC method returned an unrecognized error",
@@ -470,7 +470,7 @@ var _ = Describe("type Handler", func() {
 					handler.ServeHTTP(response, request)
 
 					Expect(response).To(HaveHTTPStatus(http.StatusOK))
-					Expect(response).To(HaveHTTPHeaderWithValue("Content-Type", "text/plain; proto=protean.test.Output"))
+					Expect(response).To(HaveHTTPHeaderWithValue("Content-Type", "text/plain; charset=utf-8; x-proto=protean.test.Output"))
 					expectStandardHeaders(response)
 
 					data, err := io.ReadAll(response.Body)
@@ -496,7 +496,7 @@ var _ = Describe("type Handler", func() {
 					expectError(
 						response,
 						http.StatusInternalServerError,
-						"text/plain",
+						"text/plain; charset=utf-8; x-proto=protean.v1.Error",
 						rpcerror.New(
 							rpcerror.Unknown,
 							"the RPC method returned an unrecognized error",
@@ -517,7 +517,7 @@ var _ = Describe("type Handler", func() {
 					expectError(
 						response,
 						http.StatusNotAcceptable,
-						protomime.TextMediaTypes[0],
+						"text/plain; charset=utf-8; x-proto=protean.v1.Error",
 						rpcerror.New(
 							rpcerror.Unknown,
 							"the client does not accept any of the media-types supported by the server",
@@ -550,7 +550,7 @@ var _ = Describe("type Handler", func() {
 					expectError(
 						response,
 						http.StatusBadRequest,
-						"text/plain",
+						"text/plain; charset=utf-8; x-proto=protean.v1.Error",
 						rpcerror.New(
 							rpcerror.Unknown,
 							"the Accept header is invalid",
@@ -574,7 +574,7 @@ var _ = Describe("type Handler", func() {
 					expectError(
 						response,
 						http.StatusInternalServerError,
-						"application/json",
+						"application/json; x-proto=protean.v1.Error",
 						rpcerror.New(
 							rpcerror.Unknown,
 							"the server produced an invalid RPC output message",
@@ -596,7 +596,7 @@ var _ = Describe("type Handler", func() {
 					expectError(
 						response,
 						http.StatusInternalServerError,
-						"application/json",
+						"application/json; x-proto=protean.v1.Error",
 						rpcerror.New(
 							rpcerror.Unknown,
 							"the RPC output message could not be marshaled to the response body",
@@ -619,7 +619,7 @@ var _ = Describe("type Handler", func() {
 					expectError(
 						response,
 						http.StatusNotFound,
-						protomime.TextMediaTypes[0],
+						"text/plain; charset=utf-8; x-proto=protean.v1.Error",
 						rpcerror.New(
 							rpcerror.NotFound,
 							message,
@@ -679,7 +679,7 @@ var _ = Describe("type Handler", func() {
 					expectError(
 						response,
 						http.StatusNotImplemented,
-						protomime.TextMediaTypes[0],
+						"text/plain; charset=utf-8; x-proto=protean.v1.Error",
 						rpcerror.New(
 							rpcerror.NotImplemented,
 							message,
@@ -724,7 +724,7 @@ var _ = Describe("type Handler", func() {
 				expectError(
 					response,
 					http.StatusNotImplemented,
-					protomime.TextMediaTypes[0],
+					"text/plain; charset=utf-8; x-proto=protean.v1.Error",
 					rpcerror.New(
 						rpcerror.NotImplemented,
 						"the HTTP method must be POST",
@@ -748,7 +748,7 @@ var _ = Describe("type Handler", func() {
 					expectError(
 						response,
 						http.StatusBadRequest,
-						"text/plain",
+						"text/plain; charset=utf-8; x-proto=protean.v1.Error",
 						rpcerror.New(
 							rpcerror.Unknown,
 							"the Content-Type header is missing or invalid",
@@ -775,7 +775,7 @@ var _ = Describe("type Handler", func() {
 				expectError(
 					response,
 					http.StatusUnsupportedMediaType,
-					"text/plain",
+					"text/plain; charset=utf-8; x-proto=protean.v1.Error",
 					rpcerror.New(
 						rpcerror.Unknown,
 						"the server does not support the 'text/xml' media-type supplied by the client",
@@ -816,23 +816,18 @@ func expectError(
 	mediaType string,
 	expect rpcerror.Error,
 ) {
-	expectedMediaType := mime.FormatMediaType(
-		mediaType,
-		map[string]string{
-			"proto": "protean.v1.Error",
-		},
-	)
+	var protoErr proteanpb.Error
 
 	Expect(response).To(HaveHTTPStatus(status))
-	Expect(response).To(HaveHTTPHeaderWithValue("Content-Type", expectedMediaType))
+	Expect(response).To(HaveHTTPHeaderWithValue("Content-Type", mediaType))
 
 	data, err := io.ReadAll(response.Body)
 	Expect(err).ShouldNot(HaveOccurred())
 
+	mediaType, _, _ = mime.ParseMediaType(mediaType)
 	unmarshaler, ok := protomime.UnmarshalerForMediaType(mediaType)
 	Expect(ok).To(BeTrue())
 
-	var protoErr proteanpb.Error
 	err = unmarshaler.Unmarshal(data, &protoErr)
 	Expect(err).ShouldNot(HaveOccurred())
 

--- a/internal/protomime/mediatypes.go
+++ b/internal/protomime/mediatypes.go
@@ -1,5 +1,11 @@
 package protomime
 
+import (
+	"mime"
+
+	"google.golang.org/protobuf/proto"
+)
+
 // MediaTypes is the set of all media types that can be used for marshaling and
 // unmarshaling Protocol Buffers messages, in order of preference.
 var MediaTypes []string
@@ -68,6 +74,20 @@ func IsText(mediaType string) bool {
 	}
 
 	return false
+}
+
+// FormatMediaType formats a complete media type, including parameters, to use
+// when marshaling m.
+func FormatMediaType(mediaType string, m proto.Message) string {
+	params := map[string]string{
+		"x-proto": string(proto.MessageName(m)),
+	}
+
+	if IsText(mediaType) {
+		params["charset"] = "utf-8"
+	}
+
+	return mime.FormatMediaType(mediaType, params)
 }
 
 func init() {

--- a/runtime/client.go
+++ b/runtime/client.go
@@ -86,14 +86,7 @@ func (c *Client) CallUnary(
 		return fmt.Errorf("unable to create HTTP request: %w", err)
 	}
 
-	inputMediaType := mime.FormatMediaType(
-		opts.InputMediaType,
-		map[string]string{
-			"proto": string(proto.MessageName(in)),
-		},
-	)
-
-	req.Header.Set("Content-Type", inputMediaType)
+	req.Header.Set("Content-Type", protomime.FormatMediaType(opts.InputMediaType, in))
 	req.Header.Set("Accept", acceptHeader(opts.OutputMediaType))
 
 	res, err := c.opts.HTTPClient.Do(req)

--- a/runtime/client.go
+++ b/runtime/client.go
@@ -86,7 +86,14 @@ func (c *Client) CallUnary(
 		return fmt.Errorf("unable to create HTTP request: %w", err)
 	}
 
-	req.Header.Set("Content-Type", opts.InputMediaType)
+	inputMediaType := mime.FormatMediaType(
+		opts.InputMediaType,
+		map[string]string{
+			"proto": string(proto.MessageName(in)),
+		},
+	)
+
+	req.Header.Set("Content-Type", inputMediaType)
 	req.Header.Set("Accept", acceptHeader(opts.OutputMediaType))
 
 	res, err := c.opts.HTTPClient.Do(req)


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR adds the `charset=utf-8` media-type parameter for `text/plain` encodings, and the `x-proto` parameter containing the name of the protocol buffers message.

#### Why make this change?

It makes it clear to humans debugging what type of protocol buffers message is supposed to be inside the response body, not just the way it was encoded.

#### Is there anything you are unsure about?

I am not sure if using the `x-` prefix for media type parameters is actually an accepted way of adding non-standard parameters to standard media types.

#### What issues does this relate to?

Follow on from #1.
